### PR TITLE
Add label support to store profiles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/alecthomas/kong v1.14.0 h1:gFgEUZWu2ZmZ+UhyZ1bDhuutbKN1nTtJTwh19Wsn21
 github.com/alecthomas/kong v1.14.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -853,6 +853,7 @@ type StoreCmd struct {
 	Show   StoreShowCmd   `cmd:"" help:"Show details of a stored profile"`
 	Import StoreImportCmd `cmd:"" help:"Import an EEPROM file into the store"`
 	Export StoreExportCmd `cmd:"" help:"Export a profile to a file"`
+	Label  StoreLabelCmd  `cmd:"" help:"Set or clear the label for a stored profile"`
 }
 
 type StoreListCmd struct{}
@@ -877,6 +878,8 @@ func (c *StoreListCmd) Run(globals *CLI) error {
 	}
 
 	fmt.Printf("%d profile(s)\n\n", len(profiles))
+	fmt.Printf("  %-12s  %-16s  %-16s  %-8s  %s\n", "Hash", "Vendor", "Part Number", "Wave", "Label")
+	fmt.Printf("  %-12s  %-16s  %-16s  %-8s  %s\n", "------------", "----------------", "----------------", "--------", "-----")
 	for hash, entry := range profiles {
 		shortHash := store.ShortHash(hash)
 		wavelength := ""
@@ -938,6 +941,9 @@ func (c *StoreShowCmd) Run(globals *CLI) error {
 	fmt.Printf("Serial:      %s\n", entry.SerialNumber)
 
 	if meta != nil {
+		if meta.Label != "" {
+			fmt.Printf("Label:       %s\n", meta.Label)
+		}
 		if meta.Identity.DateCode != "" {
 			fmt.Printf("Date Code:   %s\n", meta.Identity.DateCode)
 		}
@@ -1036,6 +1042,48 @@ func (c *StoreExportCmd) Run(globals *CLI) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "Exported to: %s\n", c.Output)
+	return nil
+}
+
+type StoreLabelCmd struct {
+	Hash  string `arg:"" help:"Profile hash (full or short)"`
+	Label string `arg:"" optional:"" help:"Label to set (omit to clear)"`
+}
+
+func (c *StoreLabelCmd) Run(globals *CLI) error {
+	config.Verbose = globals.Verbose
+
+	s, err := store.OpenDefault()
+	if err != nil {
+		return fmt.Errorf("failed to open store: %w", err)
+	}
+
+	profiles, err := s.ListWithHashes()
+	if err != nil {
+		return fmt.Errorf("failed to list profiles: %w", err)
+	}
+
+	var fullHash string
+	for hash := range profiles {
+		if hash == c.Hash || store.ShortHash(hash) == c.Hash || hash[7:] == c.Hash {
+			fullHash = hash
+			break
+		}
+	}
+
+	if fullHash == "" {
+		return fmt.Errorf("profile not found: %s", c.Hash)
+	}
+
+	if err := s.SetLabel(fullHash, c.Label); err != nil {
+		return fmt.Errorf("failed to set label: %w", err)
+	}
+
+	if c.Label == "" {
+		fmt.Fprintf(os.Stderr, "Label cleared.\n")
+	} else {
+		fmt.Fprintf(os.Stderr, "Label set: %s\n", c.Label)
+	}
 	return nil
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -883,11 +883,12 @@ func (c *StoreListCmd) Run(globals *CLI) error {
 		if entry.WavelengthNM > 0 {
 			wavelength = fmt.Sprintf("%dnm", entry.WavelengthNM)
 		}
-		fmt.Printf("  %-12s  %-16s  %-16s  %s\n",
+		fmt.Printf("  %-12s  %-16s  %-16s  %-8s  %s\n",
 			shortHash,
 			truncate(entry.VendorName, 16),
 			truncate(entry.PartNumber, 16),
-			wavelength)
+			wavelength,
+			entry.Label)
 	}
 
 	return nil

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -7,6 +7,7 @@ import (
 
 // Metadata contains parsed information about a module profile.
 type Metadata struct {
+	Label       string    `json:"label,omitempty"`
 	ContentHash string    `json:"content_hash"`
 	ModuleType  string    `json:"module_type"` // "SFP", "QSFP", "QSFP+", "QSFP28"
 	Size        int       `json:"size"`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -25,6 +25,7 @@ type Index struct {
 
 // IndexEntry contains summary info for quick listing.
 type IndexEntry struct {
+	Label        string    `json:"label,omitempty"`
 	VendorName   string    `json:"vendor_name"`
 	PartNumber   string    `json:"part_number"`
 	SerialNumber string    `json:"serial_number"`
@@ -197,6 +198,26 @@ func (s *Store) Export(hash, destPath string) error {
 	return os.WriteFile(destPath, data, 0644)
 }
 
+// SetLabel sets a user-defined label for a profile.
+func (s *Store) SetLabel(hash, label string) error {
+	meta, err := s.GetMetadata(hash)
+	if err != nil {
+		return fmt.Errorf("failed to read metadata: %w", err)
+	}
+	meta.Label = label
+	meta.UpdatedAt = time.Now()
+
+	metaPath := filepath.Join(s.metadataDir, hashToFilename(hash)+".json")
+	metaJSON, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+	if err := os.WriteFile(metaPath, metaJSON, 0644); err != nil {
+		return fmt.Errorf("failed to write metadata: %w", err)
+	}
+	return s.updateIndex(hash, meta)
+}
+
 // Count returns the number of profiles in the store.
 func (s *Store) Count() (int, error) {
 	index, err := s.loadIndex()
@@ -232,6 +253,7 @@ func (s *Store) updateIndex(hash string, meta *Metadata) error {
 	}
 
 	index.Profiles[hash] = IndexEntry{
+		Label:        meta.Label,
 		VendorName:   meta.Identity.VendorName,
 		PartNumber:   meta.Identity.PartNumber,
 		SerialNumber: meta.Identity.SerialNumber,

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -4,17 +4,18 @@ import "github.com/charmbracelet/bubbles/key"
 
 // KeyMap defines all keybindings for the TUI.
 type KeyMap struct {
-	Up       key.Binding
-	Down     key.Binding
-	Left     key.Binding
-	Right    key.Binding
-	Select   key.Binding
-	Back     key.Binding
-	Quit     key.Binding
-	Help     key.Binding
-	Refresh  key.Binding
-	Search   key.Binding
-	Connect  key.Binding
+	Up        key.Binding
+	Down      key.Binding
+	Left      key.Binding
+	Right     key.Binding
+	Select    key.Binding
+	Back      key.Binding
+	Quit      key.Binding
+	Help      key.Binding
+	Refresh   key.Binding
+	Search    key.Binding
+	Connect   key.Binding
+	EditLabel key.Binding
 }
 
 // DefaultKeyMap returns the default vim-style keybindings.
@@ -63,6 +64,10 @@ func DefaultKeyMap() KeyMap {
 		Connect: key.NewBinding(
 			key.WithKeys("c"),
 			key.WithHelp("c", "connect"),
+		),
+		EditLabel: key.NewBinding(
+			key.WithKeys("e"),
+			key.WithHelp("e", "edit label"),
 		),
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/progress"
 	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"tinygo.org/x/bluetooth"
@@ -117,6 +118,10 @@ type Model struct {
 	filepicker       filepicker.Model
 	filePickerActive bool
 	selectedFilePath string
+
+	// Label editing
+	labelInput   textinput.Model
+	editingLabel bool
 
 	// Components
 	keys    KeyMap
@@ -266,6 +271,9 @@ type firmwareFlashCompleteMsg struct {
 // fwRebootReconnectMsg triggers auto-reconnect after firmware reboot.
 type fwRebootReconnectMsg time.Time
 
+// labelSavedMsg signals that a module label was saved.
+type labelSavedMsg struct{ err error }
+
 // NewModel creates a new TUI model.
 func NewModel() Model {
 	h := help.New()
@@ -307,6 +315,12 @@ func NewModel() Model {
 			View:        ViewFirmware,
 		},
 	}
+
+	// Initialize label text input
+	ti := textinput.New()
+	ti.Placeholder = "Enter label..."
+	ti.CharLimit = 64
+	m.labelInput = ti
 
 	// Initialize file picker for firmware selection
 	fp := filepicker.New()
@@ -591,6 +605,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusMsg = fmt.Sprintf("Snapshot saved to store: %s", store.ShortHash(msg.hash))
 		return m, nil
 
+	case labelSavedMsg:
+		m.editingLabel = false
+		if msg.err != nil {
+			m.errorMsg = fmt.Sprintf("Failed to save label: %v", msg.err)
+			return m, nil
+		}
+		m.loadStoreProfiles()
+		m.statusMsg = "Label saved"
+		return m, nil
+
 	case moduleDetailsMsg:
 		// Always update moduleDetails - use empty struct on error
 		if msg.err == nil && msg.details != nil {
@@ -798,6 +822,21 @@ func (m Model) handleDisconnect() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Intercept keys during label editing
+	if m.editingLabel {
+		switch msg.Type {
+		case tea.KeyEnter:
+			return m, saveLabelCmd(m.selectedHash, m.labelInput.Value())
+		case tea.KeyEsc:
+			m.editingLabel = false
+			return m, nil
+		default:
+			var cmd tea.Cmd
+			m.labelInput, cmd = m.labelInput.Update(msg)
+			return m, cmd
+		}
+	}
+
 	// Intercept keys during firmware flash: only allow ESC to cancel
 	if m.fwFlashing && m.cancelFlash != nil {
 		if key.Matches(msg, m.keys.Back) || key.Matches(msg, m.keys.Quit) {
@@ -858,6 +897,18 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, scanForDeviceCmd
 		}
 		return m, nil
+
+	case key.Matches(msg, m.keys.EditLabel):
+		if m.view == ViewStoreDetail && m.selectedHash != "" {
+			currentLabel := ""
+			if entry, ok := m.storeProfiles[m.selectedHash]; ok {
+				currentLabel = entry.Label
+			}
+			m.labelInput.SetValue(currentLabel)
+			m.labelInput.Focus()
+			m.editingLabel = true
+			return m, nil
+		}
 	}
 
 	return m, nil
@@ -1527,11 +1578,12 @@ func (m Model) viewStore() string {
 				wavelength = fmt.Sprintf("%dnm", entry.WavelengthNM)
 			}
 
-			line := fmt.Sprintf("%-12s  %-16s  %-16s  %s",
+			line := fmt.Sprintf("%-12s  %-16s  %-16s  %-8s  %s",
 				shortHash,
 				truncate(entry.VendorName, 16),
 				truncate(entry.PartNumber, 16),
-				wavelength)
+				wavelength,
+				truncate(entry.Label, 24))
 
 			if i == m.cursor {
 				b.WriteString(m.styles.MenuItemSelected.Render("> " + line))
@@ -1585,6 +1637,20 @@ func (m Model) viewStoreDetail() string {
 			b.WriteString(m.renderField("Connector", meta.Specs.ConnectorType))
 		}
 		b.WriteString(m.renderField("Sources", fmt.Sprintf("%d", len(meta.Sources))))
+	}
+
+	// Label field
+	b.WriteString("\n")
+	if m.editingLabel {
+		b.WriteString(m.styles.Highlight.Render("Label") + "  " + m.labelInput.View() + "\n")
+	} else {
+		labelVal := entry.Label
+		if labelVal == "" {
+			labelVal = m.styles.Muted.Render("(none)")
+		}
+		b.WriteString(m.renderField("Label", labelVal))
+		b.WriteString(m.styles.Muted.Render("[e] edit label"))
+		b.WriteString("\n")
 	}
 
 	b.WriteString("\n")
@@ -2324,5 +2390,16 @@ func refreshCachedFirmwareCmd() tea.Cmd {
 		}
 		cached, _ := cache.List()
 		return cachedFirmwareMsg{cached: cached}
+	}
+}
+
+// saveLabelCmd saves a user-defined label for a store profile.
+func saveLabelCmd(hash, label string) tea.Cmd {
+	return func() tea.Msg {
+		s, err := store.OpenDefault()
+		if err != nil {
+			return labelSavedMsg{err: err}
+		}
+		return labelSavedMsg{err: s.SetLabel(hash, label)}
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1567,6 +1567,13 @@ func (m Model) viewStore() string {
 	} else {
 		b.WriteString(fmt.Sprintf("%d profile(s)\n\n", len(m.storeProfiles)))
 
+		header := fmt.Sprintf("  %-12s  %-16s  %-16s  %-8s  %s", "Hash", "Vendor", "Part Number", "Wave", "Label")
+		b.WriteString(m.styles.Muted.Render(header))
+		b.WriteString("\n")
+		sep := fmt.Sprintf("  %-12s  %-16s  %-16s  %-8s  %s", "------------", "----------------", "----------------", "--------", "-----")
+		b.WriteString(m.styles.Muted.Render(sep))
+		b.WriteString("\n")
+
 		hashes := m.getSortedHashes()
 		for i, hash := range hashes {
 			entry := m.storeProfiles[hash]


### PR DESCRIPTION
## Summary

- Add user-settable label field to store module metadata, persisted in profile JSON
- `store list` (CLI + TUI) now shows a label column with aligned headers
- `store show` (CLI) and profile detail view (TUI) now display the label field
- New `store label <hash> [label]` CLI command to set or clear a label
- TUI profile detail view supports inline label editing with `[e]`
- TUI module list shows column labels

## Examples
```
./sfpw-tool store label 3399a9714166 "Cisco 1G-SX"
Label set: Cisco 1G-SX

./sfpw-tool store show 3399a9714166
Hash:        3399a9714166
Type:        SFP
Vendor:      FINISAR CORP.
Part Number: FTLF8519P3BNL
Serial:      {REDACTED}
Label:       Cisco 1G-SX
Date Code:   191124
Wavelength:  850 nm
Connector:   LC
Sources:     1

Export: sfpw store export 3399a9714166 <file>

./sfpw-tool store list
4 profile(s)

  Hash          Vendor            Part Number       Wave      Label
  ------------  ----------------  ----------------  --------  -----
  227fe3c036da  FS                SFP-1G35-BX10     1310nm
  3399a9714166  FINISAR CORP.     FTLF8519P3BNL     850nm     Cisco 1G-SX
  be093177c1e8  OEM               SFP-10G-T         850nm     10g-Copper
```

Resolves #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)